### PR TITLE
Allow . in version numbers

### DIFF
--- a/testing/mulver_test.sh
+++ b/testing/mulver_test.sh
@@ -8,7 +8,7 @@ pg_multver_src_dir="$baseadr/$pg_multver_src_dir";
 [ ! -d "$pg_multver_src_dir" ] && (echo "No PostgreSQL source code directory
 Press any key"; read x; exit;);
 
-one_ver="$3";
+one_ver=$(echo "$3"| tr '.' '_');
 ver=$(ls -1 "$baseadr/$fdwname/expected/" | tr '.' '_');
 echo "$ver";
 


### PR DESCRIPTION
After this commit you can also write not only PostgreSQL branch number like `16_0` but also `16.0` if testing cycle is limited to one of PostgreSQL versions.